### PR TITLE
Make assignments to textArea.style.{top,left} strings.

### DIFF
--- a/cbn-copy-clipboard-behavior.html
+++ b/cbn-copy-clipboard-behavior.html
@@ -36,8 +36,8 @@
 			//
 			// Place in top-left corner of screen regardless of scroll position.
 			textArea.style.position = 'fixed';
-			textArea.style.top = 0;
-			textArea.style.left = 0;
+			textArea.style.top = '0';
+			textArea.style.left = '0';
 			// Ensure it has a small width and height. Setting to 1px / 1em
 			// doesn't work as this gives a negative w/h on some browsers.
 			textArea.style.width = '2em';


### PR DESCRIPTION
While assigning a number works, it breaks the build when trying to compile this library with strict type checking enabled, giving the following error message:

```
ERROR: …/cbn-copy-clipboard-behavior_cbn-copy-clipboard-behavior_crisp.js:32 assignment to property top of CSSStyleDeclaration
found   : number
required: string
      textArea.style.top = 0;
      ^^^^^^^^^^^^^^^^^^^^^^
```

This is because the `top` and `left` properties of `CSSStyleDeclaration` are defined as strings.